### PR TITLE
feat/Team member views built out and communicating with BE

### DIFF
--- a/client/src/components/TeamMembers/TeamMemberPageContainer/AddTeamMemberPage.js
+++ b/client/src/components/TeamMembers/TeamMemberPageContainer/AddTeamMemberPage.js
@@ -87,13 +87,23 @@ class TeamMemberPage extends React.Component {
       phone_number: "",
       user_id: "",
       text_on: true,
-      email_on: false
+      email_on: false,
+      slack_on: false,
+      manager: null,
+      mentor: null
     },
     assignments: [],
     training_series: [],
     isRouting: false,
-    snackState: false
+    snackState: false,
+    memberManager: null,
+    memberMentor: null,
+    otherTeamMembers: []
   };
+
+  componentDidMount() {
+    this.setState({ otherTeamMembers: this.props.teamMembers });
+  }
 
   handleChange = name => event => {
     this.setState({
@@ -135,28 +145,46 @@ class TeamMemberPage extends React.Component {
     this.props.history.push("/home");
   };
 
+  selectHandler = (e, relationType) => {
+    let val = e.target.value !== "null" ? parseInt(e.target.value) : null;
+    this.setState({
+      teamMember: {
+        ...this.state.teamMember,
+        [e.target.name]: val
+      },
+      [relationType]: val
+        ? this.state.otherTeamMembers.find(mbr => mbr.id === val)
+        : null
+    });
+  };
+
   render() {
     const { classes } = this.props;
-    const { text_on, email_on } = this.state.teamMember;
+    const { text_on, email_on, slack_on } = this.state.teamMember;
 
-    let textDisabled;
-    let emailDisabled;
+    let textEnabled;
+    let emailEnabled;
+    let slackEnabled;
     let addDisabled = false;
     //console.log(addDisabled);
 
-    if (text_on && !email_on) {
-      textDisabled = true;
+    if (text_on && !email_on && !slack_on) {
+      textEnabled = true;
     }
 
-    if (email_on && !text_on) {
-      emailDisabled = true;
+    if (email_on && !text_on && !slack_on) {
+      emailEnabled = true;
     }
 
-    if (email_on && text_on) {
-      textDisabled = false;
-      emailDisabled = false;
+    if (slack_on && !text_on && !slack_on) {
+      slackEnabled = true;
     }
 
+    if (email_on && text_on && slack_on) {
+      textEnabled = false;
+      emailEnabled = false;
+      slackEnabled = false;
+    }
     //Checks to see if one number has been entered and if the full number matches
     if (
       /^$/gm.test(this.state.teamMember.phone_number) === true ||
@@ -228,6 +256,65 @@ class TeamMemberPage extends React.Component {
                 margin="normal"
               />
             </MemberInfoContainer>
+            <div className="mentor display">
+              Mentor
+              {this.state.memberMentor !== null
+                ? `: ${this.state.memberMentor.first_name} ${
+                    this.state.memberMentor.last_name
+                  }`
+                : ": none"}
+            </div>
+            <form className="mentor select">
+              <select
+                name="mentor"
+                value={this.state.teamMember.mentor}
+                onChange={e => this.selectHandler(e, "memberMentor")}
+              >
+                <option>select mentor</option>{" "}
+                <option value="null">none</option>
+                {this.state.otherTeamMembers
+                  .filter(
+                    mbr =>
+                      mbr.id !== this.state.teamMember.mentor &&
+                      mbr.id !== this.state.teamMember.manager
+                  )
+                  .map(mbr => (
+                    <option key={mbr.id} value={mbr.id}>
+                      {mbr.first_name} {mbr.last_name}
+                    </option>
+                  ))}
+              </select>
+            </form>
+
+            <div className="manager display">
+              Manager
+              {this.state.memberManager !== null
+                ? `: ${this.state.memberManager.first_name} ${
+                    this.state.memberManager.last_name
+                  }`
+                : ": none"}
+            </div>
+            <form className="manager select">
+              <select
+                name="manager"
+                value={this.state.teamMember.manager}
+                onChange={e => this.selectHandler(e, "memberManager")}
+              >
+                <option>select manager</option>
+                <option value="null">none</option>
+                {this.state.otherTeamMembers
+                  .filter(
+                    mbr =>
+                      mbr.id !== this.state.teamMember.mentor &&
+                      mbr.id !== this.state.teamMember.manager
+                  )
+                  .map(mbr => (
+                    <option key={mbr.id} value={mbr.id}>
+                      {mbr.first_name} {mbr.last_name}
+                    </option>
+                  ))}
+              </select>
+            </form>
 
             <ButtonContainer>
               <FormControlLabel
@@ -235,7 +322,7 @@ class TeamMemberPage extends React.Component {
                   <Switch
                     checked={this.state.teamMember.text_on}
                     onChange={
-                      textDisabled ? null : this.handleToggleChange("text_on")
+                      textEnabled ? null : this.handleToggleChange("text_on")
                     }
                     value="text_on"
                     color="default"
@@ -258,7 +345,7 @@ class TeamMemberPage extends React.Component {
                     disabled={this.state.teamMember.email === ""}
                     checked={this.state.teamMember.email_on}
                     onChange={
-                      emailDisabled ? null : this.handleToggleChange("email_on")
+                      emailEnabled ? null : this.handleToggleChange("email_on")
                     }
                     value="email_on"
                     color="default"
@@ -273,6 +360,28 @@ class TeamMemberPage extends React.Component {
                   this.state.teamMember.email_on
                     ? "Email Active"
                     : "Email Inactive"
+                }
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={this.state.teamMember.slack_on}
+                    onChange={
+                      slackEnabled ? null : this.handleToggleChange("slack_on")
+                    }
+                    value="slack_on"
+                    color="default"
+                    style={
+                      this.state.teamMember.slack_on
+                        ? { color: "#451476" }
+                        : { color: "#edeaea" }
+                    }
+                  />
+                }
+                label={
+                  this.state.teamMember.slack_on
+                    ? "Slack Active"
+                    : "Slack Inactive"
                 }
               />
             </ButtonContainer>
@@ -308,7 +417,8 @@ class TeamMemberPage extends React.Component {
 const mapStateToProps = state => {
   return {
     addSuccess: state.teamMembersReducer.status.addSuccess,
-    teamMember: state.teamMembersReducer.teamMember
+    teamMember: state.teamMembersReducer.teamMember,
+    teamMembers: state.teamMembersReducer.teamMembers
   };
 };
 

--- a/client/src/components/TeamMembers/TeamMemberPageContainer/TeamMemberPageView.js
+++ b/client/src/components/TeamMembers/TeamMemberPageContainer/TeamMemberPageView.js
@@ -36,6 +36,7 @@ class TeamMemberPageView extends React.Component {
 
   editTeamMemberSubmit = (e, changes) => {
     e.preventDefault();
+    console.log(changes);
     this.props.editTeamMember(this.props.match.params.id, changes);
   };
 

--- a/client/src/components/TeamMembers/TeamMemberPageContainer/TeamMemberPageView.js
+++ b/client/src/components/TeamMembers/TeamMemberPageContainer/TeamMemberPageView.js
@@ -36,7 +36,7 @@ class TeamMemberPageView extends React.Component {
 
   editTeamMemberSubmit = (e, changes) => {
     e.preventDefault();
-    console.log(changes);
+    // console.log(changes);
     this.props.editTeamMember(this.props.match.params.id, changes);
   };
 

--- a/client/src/components/TrainingSeries/AddMembersToTrainingSeries/AddMembersView.js
+++ b/client/src/components/TrainingSeries/AddMembersToTrainingSeries/AddMembersView.js
@@ -130,7 +130,7 @@ class AddMembersView extends Component {
       this.setState({ [name]: event.target.value });
     },
     routeToPostPage: () => {
-      console.log(this.state);
+      // console.log(this.state);
       this.props.history.push(
         `/home/training-series/${this.state.trainingSeriesID}`
       );

--- a/client/src/components/TrainingSeries/TrainingSeries.js
+++ b/client/src/components/TrainingSeries/TrainingSeries.js
@@ -36,14 +36,16 @@ function SeriesCard(props) {
   //console.log("TRAINING SERIES LIST", props);
 
   const { classes } = props;
-  const [postLength, setPostLength] = useState(0);
+  const [messageLength, setMessageLength] = useState(0);
   const [assignedLength, setAssignedLength] = useState(0);
 
-  async function getPostCount() {
+  async function getMessageCount() {
     await axios
-      .get(`${process.env.REACT_APP_API}/api/training-series/${props.id}/posts`)
+      .get(
+        `${process.env.REACT_APP_API}/api/training-series/${props.id}/messages`
+      )
       .then(res => {
-        setPostLength(res.data.posts.length);
+        setMessageLength(res.data.messages.length);
       })
       .catch(err => {
         //console.log(err);
@@ -66,21 +68,21 @@ function SeriesCard(props) {
   }
 
   useEffect(() => {
-    getPostCount();
+    getMessageCount();
     getMemberCount();
   });
 
   const routeToTrainingSeriesPage = e => {
     e.preventDefault();
 
-    props.history.push(`home/training-series/${props.id}`);
+    props.history.push(`home/training-series/${props.data.id}`);
   };
 
   return (
     <ListItem component="li" className={classes.listItem}>
       <ListItemText
         primary={props.data.title}
-        secondary={`Messages: ${postLength} | Assigned: ${assignedLength}`}
+        secondary={`Messages: ${messageLength} | Assigned: ${assignedLength}`}
         onClick={e => routeToTrainingSeriesPage(e)}
       />
 

--- a/client/src/store/actions/messagesActions.js
+++ b/client/src/store/actions/messagesActions.js
@@ -31,13 +31,13 @@ export const getTrainingSeriesMessages = id => dispatch => {
     type: GET_MESSAGES_START
   });
   axios
-    .get(`${process.env.REACT_APP_API}/api/training-series/${id}/posts`)
-    .then(res =>
+    .get(`${process.env.REACT_APP_API}/api/training-series/${id}/messages`)
+    .then(res => {
       dispatch({
         type: GET_MESSAGES_SUCCESS,
         payload: res.data
-      })
-    )
+      });
+    })
     .catch(err => dispatch({ type: GET_MESSAGES_FAIL, error: err }));
 };
 
@@ -55,7 +55,6 @@ export const getMessageById = id => dispatch => {
 // POST a new message
 export const createAMessage = (message, trainingSeriesID) => dispatch => {
   dispatch({ type: ADD_MESSAGE_START });
-  //console.log("post in createAMessage", post);
   axios
     .post(`${process.env.REACT_APP_API}/api/messages`, message)
     .then(res =>

--- a/client/src/store/actions/teamMembersActions.js
+++ b/client/src/store/actions/teamMembersActions.js
@@ -41,23 +41,19 @@ const baseUrl = `${process.env.REACT_APP_API}/api`;
 
 export const getTeamMembers = id => dispatch => {
   dispatch({ type: FETCH_TEAM_START });
-  console.log("user id to pull team members with: ", id);
   axios
     .get(`${baseUrl}/users/${id}/team-members`)
     .then(res => {
-      console.log("team members being fetched: ", res.data);
       dispatch({ type: FETCH_TEAM_SUCCESS, payload: res.data.members });
     })
     .catch(err => dispatch({ type: FETCH_TEAM_FAIL, payload: err }));
 };
 
 export const addTeamMember = teamMember => dispatch => {
-  console.log("member to be added: ", teamMember);
   dispatch({ type: ADD_MEMBER_START });
   axios
     .post(`${baseUrl}/team-members`, teamMember)
     .then(res => {
-      console.log("added team member:", res.data);
       dispatch({ type: ADD_MEMBER_SUCCESS, payload: res.data.newTeamMember });
     })
     .then(() => history.push({ pathname: "/home", state: { success: true } }))
@@ -65,7 +61,6 @@ export const addTeamMember = teamMember => dispatch => {
 };
 
 export const editTeamMember = (id, changes) => dispatch => {
-  //console.log(changes);
   dispatch({ type: EDIT_MEMBER_START });
   axios
     .put(`${baseUrl}/team-members/${id}`, changes)
@@ -80,7 +75,6 @@ export const editTeamMember = (id, changes) => dispatch => {
 
 export const deleteTeamMember = (teamMemberID, userID) => dispatch => {
   dispatch({ type: DELETE_MEMBER_START });
-  console.log("tID and uID to be deleted: ", teamMemberID, userID);
   axios
     .delete(`${baseUrl}/team-members/${teamMemberID}`)
     .then(res => {
@@ -98,13 +92,11 @@ export const deleteTeamMember = (teamMemberID, userID) => dispatch => {
 };
 
 export const getTeamMemberByID = id => dispatch => {
-  console.log("ID of individual team member being fetched: ", id);
   dispatch({ type: FETCH_SINGLE_MEMBER_START });
 
   axios
     .get(`${baseUrl}/team-members/${id}`)
     .then(res => {
-      console.log("team member that was fetched: ", res.data);
       dispatch({
         type: FETCH_SINGLE_MEMBER_SUCCESS,
         payload: res.data

--- a/client/src/store/reducers/teamMembersReducer.js
+++ b/client/src/store/reducers/teamMembersReducer.js
@@ -152,7 +152,7 @@ const teamMembersReducer = (state = initialState, action) => {
         }
       };
     case EDIT_MEMBER_SUCCESS:
-      const updatedMember = state.teamMembers.map(member => {
+      const updatedMembers = state.teamMembers.map(member => {
         if (member.id === action.payload.id) {
           return {
             ...member,
@@ -164,7 +164,7 @@ const teamMembersReducer = (state = initialState, action) => {
       });
       return {
         ...state,
-        teamMembers: updatedMember,
+        teamMembers: updatedMembers,
         status: {
           ...state.status,
           isEditing: false,


### PR DESCRIPTION
# Description

Team member views updated according to MVP goals:
-can add mentor/manager relationships to other team members in Create or Edit view
-can toggle Slack notification on/off just like text and email options in Create & Edit view
-verified that existing Training Series assigned to team member can be viewed in Edit view
-basic template set up for Messages linked to said Training Series in place (needs further testing, waiting on Training Series functionality to be updated from @GannonDetroit)
-Slack member selection not implemented as of yet, will be implemented by @ajb85 but will be added to Create and Edit views

Schema names also reverted back to "messages" instead of "posts" when dealing with messagesReducer and actions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested locally within browser and within local pslq database to verify SQL operations performing separately

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] There are no merge conflicts
