### PR TITLE
Associate Team Member's with a Slack ID

### DIFF
--- a/client/src/components/TeamMembers/TeamMemberPageContainer/AddTeamMemberPage.js
+++ b/client/src/components/TeamMembers/TeamMemberPageContainer/AddTeamMemberPage.js
@@ -1,5 +1,6 @@
 import React from "react";
 import NumberFormat from "react-number-format";
+import axios from 'axios';
 
 import styled from "styled-components";
 
@@ -87,13 +88,20 @@ class TeamMemberPage extends React.Component {
       phone_number: "",
       user_id: "",
       text_on: true,
-      email_on: false
+      email_on: false,
+      slack_id: ""
     },
     assignments: [],
     training_series: [],
     isRouting: false,
-    snackState: false
+    snackState: false,
+    slackUsers: null,
   };
+
+  componentDidMount = async () => {
+    const { data } = await axios.get(`${process.env.REACT_APP_API}/api/slack/`)
+    this.setState(() => ({ slackUsers: data }))
+  }
 
   handleChange = name => event => {
     this.setState({
@@ -138,6 +146,7 @@ class TeamMemberPage extends React.Component {
   render() {
     const { classes } = this.props;
     const { text_on, email_on } = this.state.teamMember;
+    console.log(this.state.slackUsers);
 
     let textDisabled;
     let emailDisabled;
@@ -227,6 +236,13 @@ class TeamMemberPage extends React.Component {
                 onChange={this.handleChange("email")}
                 margin="normal"
               />
+            </MemberInfoContainer>
+            <MemberInfoContainer>
+              <select value={this.state.teamMember.slack_id} onChange={this.handleChange("slack_id")}>
+                {this.state.slackUsers && this.state.slackUsers.map(user => (
+                  <option key={user.id} value={user.id}>{user.real_name}</option>
+                ))}
+              </select>
             </MemberInfoContainer>
 
             <ButtonContainer>


### PR DESCRIPTION
# Description

This adds the ability to associate Team Members with a slack ID so that Training Bot can message them.

NOTE: @GannonDetroit -> You'll need to add our slack token to Netlify's config vars for this to work correctly.

@ajb85 If you could pass the temporary credentials to @GannonDetroit so that this can work that would be great.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Manually, by creating a new team member and associating them with their slack ID.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
