### PR TITLE
:sparkles: TS tab finished

### DIFF
--- a/client/src/components/Containers/Dashboard/Dashboard/Dashboard.js
+++ b/client/src/components/Containers/Dashboard/Dashboard/Dashboard.js
@@ -26,7 +26,7 @@ function Dashboard(props) {
         onChange={(e, value) => {
           setTopTab(value);
         }}
-        style={{ width: "80%" }}
+        style={{ width: "80%", whiteSpace: "nowrap" }}
       >
         <BottomNavigationAction
           label="Overview"

--- a/client/src/components/Sections/TeamMembers/TeamMembersTab/TeamMembersTab.js
+++ b/client/src/components/Sections/TeamMembers/TeamMembersTab/TeamMembersTab.js
@@ -23,7 +23,7 @@ const TeamMembersTab = props => {
   const [localTeamMembers, setLocalTeamMembers] = useState([]);
   const [limit] = useState(8);
   const [offset, setOffset] = useState(0);
-  const { getTeamMembers, userId, teamMembers } = props;
+  //const { getTeamMembers, userId, teamMembers } = props;
 
   useEffect(() => {
     props.getTeamMembers(props.userId);

--- a/client/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeries.js
+++ b/client/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeries.js
@@ -39,7 +39,7 @@ function SeriesCard(props) {
   const [messageLength, setMessageLength] = useState(0);
   const [assignedLength, setAssignedLength] = useState(0);
 
-  const { id } = props.data;
+  //const { id } = props.data;
   const url = `${process.env.REACT_APP_API}/api/training-series/${
     props.data.id
   }`;

--- a/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTab.js
+++ b/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTab.js
@@ -67,7 +67,9 @@ const TrainingSeriesTab = props => {
       />
       {props.trainingSeries
         .slice(offset, limit + offset)
-        .filter(series => series.title.includes(searchValue))
+        .filter(series =>
+          series.title.toLowerCase().includes(searchValue.toLowerCase())
+        )
         .map(series => {
           return (
             <Series

--- a/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTabSingle.js
+++ b/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTabSingle.js
@@ -1,15 +1,13 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { Grid, Typography } from "@material-ui/core/";
+import { Select } from "./TrainingSeriesTabStyles.js";
 
 export default function TrainingSeriesTabSingle(props) {
   const [postLength, setPostLength] = useState(0);
   const [assignedLength, setAssignedLength] = useState(0);
   const [assignments, setAssignments] = useState([]);
-
-  const {
-    series: { id }
-  } = props;
+  const [daysLong, setDaysLong] = useState([]);
 
   useEffect(() => {
     const url = `${process.env.REACT_APP_API}/api/training-series/${
@@ -18,7 +16,13 @@ export default function TrainingSeriesTabSingle(props) {
 
     axios
       .get(`${url}/messages`)
-      .then(res => setPostLength(res.data.messages.length))
+      .then(res => {
+        setPostLength(res.data.messages.length);
+        const longestDaysFromStart = res.data.messages.sort(
+          (a, b) => b.days_from_start - a.days_from_start
+        );
+        setDaysLong(longestDaysFromStart[0].days_from_start);
+      })
       .catch(err => setPostLength(err));
 
     axios
@@ -37,13 +41,27 @@ export default function TrainingSeriesTabSingle(props) {
           <Typography variant="h6">{props.series.title}</Typography>
           <hr />
         </Grid>
-        <Grid item xs={6}>
-          <Typography style={{ color: "gray" }} variant="caption">
-            {props.series.description}
-          </Typography>
+        <Grid item xs={8}>
+          <p style={{ marginTop: 0 }}>This training series is assigned to:</p>
+          <Select
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            <option value="default">default</option>
+            <option value="remove me">
+              once backend is up, finish this!!!
+            </option>
+            {assignments.map(assignment => {
+              console.log(assignment);
+            })}
+          </Select>
+          <p>
+            and is <span style={{ color: "blue" }}>{daysLong}</span> days long.
+          </p>
         </Grid>
 
-        <Grid item xs={6} align="center">
+        <Grid item xs={4} align="center">
           <Grid item>
             <Typography variant="overline">messages: {postLength}</Typography>
           </Grid>

--- a/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTabStyles.js
+++ b/client/src/components/Sections/TrainingSeries/TabTSComponents/TrainingSeriesTabStyles.js
@@ -22,3 +22,9 @@ export const Series = styled(Paper)`
     background: #f8f8f8;
   }
 `;
+
+export const Select = styled.select`
+  width: 125px;
+  height: 35px;
+  border: 1px solid #441576;
+`;


### PR DESCRIPTION
This is from what i can see all wel need to display for the Training Series Tab. Only need to hook up one more piece once the backends working and this should be about it (beyond potential styling changes).

# Description

This pull includes all of what i expect we will want to display for the training series tab. One more thing needs to get hooked up (displaying the actual list of employees) but I want to wait until the new backend is up and working to hook that up. could also potentially include a quick list of all of the links included in the training series at a glance if we want that.

This pull also includes a hand full of fixes which remove some nagging warnings that were lingering in the console.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
