### PR TITLE
:bug: Fix displayed "assigned" count for each Series

### DIFF
--- a/src/components/Sections/Notifications/Notification/Notification.js
+++ b/src/components/Sections/Notifications/Notification/Notification.js
@@ -30,12 +30,11 @@ function Notification(props) {
     .add(1, "hours")
     .format("MMMM Do");
 
-  //todo:add tm.last_name to list of properties returned by Notifications.find() in BE, then take out || "Snow"
   return (
     <ListItem className={classes.listItem}>
       <ListItemText
         primary={`${subject} | ${series}`}
-        secondary={`${first_name} ${last_name || "Snow"} | ${
+        secondary={`${first_name} ${last_name} | ${
           email
             ? email
             : phone_number

--- a/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeries.js
+++ b/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeries.js
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { withRouter } from "react-router";
+import { connect } from "react-redux";
+
 //PropTypes
 import PropTypes from "prop-types";
 
@@ -33,7 +35,7 @@ const styles = {
 };
 
 function SeriesCard(props) {
-  const { classes } = props;
+  const { classes, notifications } = props;
   const [messageLength, setMessageLength] = useState(0);
   const [assignedLength, setAssignedLength] = useState(0);
 
@@ -43,19 +45,23 @@ function SeriesCard(props) {
   async function getMessageCount() {
     try {
       const { data } = await axios.get(`${url}/messages`);
-      console.log(data);
+      // console.log(data);
       setMessageLength(data.messages.length);
     } catch (err) {
       console.log(err);
     }
   }
-  async function getMemberCount() {
-    try {
-      const { data } = await axios.get(`${url}/assignments`);
-      setAssignedLength(data.assignments.length);
-    } catch (err) {
-      console.log(err);
-    }
+  function getMemberCount() {
+    //first filter all notifications brought in from Redux state for only ones linked to this series
+    const filteredNotifs = props.notifications.filter(
+      n => n.training_series_id === id
+    );
+    //push each unique team member id from remaining notifications, length of this is # of assigned members
+    let tmIds = [];
+    filteredNotifs.forEach(
+      n => !tmIds.includes(n.team_member_id) && tmIds.push(n.team_member_id)
+    );
+    setAssignedLength(tmIds.length);
   }
 
   useEffect(() => {
@@ -90,4 +96,13 @@ SeriesCard.propTypes = {
   classes: PropTypes.object.isRequired
 };
 
-export default withStyles(styles)(withRouter(SeriesCard));
+const mapStateToProps = state => {
+  return {
+    notifications: state.notificationsReducer.notifications
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(withStyles(styles)(withRouter(SeriesCard)));

--- a/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeriesMessages.js
+++ b/src/components/Sections/TrainingSeries/DashTSComponents/TrainingSeriesMessages.js
@@ -7,7 +7,7 @@ import axios from "axios";
 
 // Components
 import DeleteModal from "components/UI/Modals/deleteModal";
-//import TrainingSeriesAssignment from "./TrainingSeriesAssignment";
+import TrainingSeriesAssignment from "./TrainingSeriesAssignment";
 
 // Redux
 import { connect } from "react-redux";
@@ -62,7 +62,7 @@ class TrainingSeriesMessages extends React.Component {
   componentDidMount() {
     this.props.getTrainingSeriesMessages(this.props.match.params.id);
     this.props.getTeamMembers(this.props.userId);
-    //this.props.getMembersAssigned(this.props.match.params.id);
+
     if (this.props.location.state) {
       this.setState({
         displaySnackbar: this.props.location.state.success
@@ -197,10 +197,25 @@ class TrainingSeriesMessages extends React.Component {
     }
 
     let assignedMembersStatus;
-    if (
-      this.props.teamMembers.length > 0 //&&
-      //this.props.assignments.length === 0
-    ) {
+
+    //first filter all notifications brought in from Redux state for only ones linked to this series
+    const filteredNotifs = this.props.notifications.filter(
+      n => n.training_series_id === parseInt(this.props.match.params.id)
+    );
+
+    //push each unique team member id from remaining notifications, length of this is # of assigned members
+    let assignedMemberIds = [];
+    filteredNotifs.forEach(
+      n =>
+        !assignedMemberIds.includes(n.team_member_id) &&
+        assignedMemberIds.push(n.team_member_id)
+    );
+    //make list of team members found in the assignedMemberIds array
+    let assignedMembers = this.props.teamMembers.filter(t =>
+      assignedMemberIds.includes(t.id)
+    );
+
+    if (this.props.teamMembers.length > 0 && assignedMembers.length === 0) {
       assignedMembersStatus = (
         <>
           <HeaderContainer>
@@ -239,12 +254,12 @@ class TrainingSeriesMessages extends React.Component {
               Assign Members
             </Button>
           </HeaderContainer>
-          {/*this.props.assignments.map(member => (
+          {assignedMembers.map(member => (
             <>
               <TrainingSeriesAssignment member={member} />
               <Divider />
             </>
-          ))*/}
+          ))}
         </>
       );
     } else {
@@ -385,6 +400,7 @@ const mapStateToProps = state => ({
   //singleTrainingSeries: state.trainingSeriesReducer.trainingSeries.filter(
   //   series => series.id === this.props.match.params.id
   // ),
+  notifications: state.notificationsReducer.notifications,
   messages: state.trainingSeriesReducer.messages,
   assignments: state.trainingSeriesReducer.assignments,
   trainingSeries: state.trainingSeriesReducer.trainingSeries,


### PR DESCRIPTION
# Description

Hooked TrainingSeries.js up with Redux store to grab notifications, filtered through them to find total number of unique team members assigned to the specific Series. This fixes the former version which was making a call to a deprecated URL of /api/training-series/:id/assignments. Also removed assignment of last name "Snow" to all team members in notifications since Notifications.find() since updated in BE to also return last_name as intended.

This PR also allows for proper display of "assigned" team members on the individual training series view via multi-step filtering of the notifications held on state.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally in own browser:
![image](https://user-images.githubusercontent.com/34550186/57548875-acb56a80-7327-11e9-9f9e-0dca78ceaae6.png)

![image](https://user-images.githubusercontent.com/34550186/57552456-96141100-7331-11e9-9030-66cd9d170f09.png)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
