### PR TITLE
:bug: Fixes issue where TM Edit data persists into Add

### DIFF
--- a/src/components/Sections/TeamMembers/Add/Add.js
+++ b/src/components/Sections/TeamMembers/Add/Add.js
@@ -33,9 +33,10 @@ function Add(props) {
     getSlackUsers();
     getTeamMembersFromProps(user_id);
     dispatch({ type: "UPDATE_MEMBER", key: "user_id", payload: user_id });
-    if (Object.keys(teamMember).length) {
+    if (teamMember) {
       dispatch({ type: "EDITING_MEMBER", payload: teamMember });
     }
+    return () => dispatch({ type: "CLEAR_MEMBER" });
   }, [dispatch, getTeamMembersFromProps, user_id, teamMember]);
 
   const phoneNumberTest = () => {
@@ -57,6 +58,14 @@ function Add(props) {
 
   const addNewTeamMember = e => {
     e.preventDefault();
+    const { teamMember } = state;
+    if (teamMember.manager_id === "") {
+      teamMember.manager_id = null;
+    }
+    if (teamMember.mentor_id === "") {
+      teamMember.mentor_id = null;
+    }
+
     props.addTeamMember(state.teamMember);
     dispatch({ type: "TOGGLE_ROUTING" });
   };
@@ -66,7 +75,9 @@ function Add(props) {
     <MainContainer>
       <form className={classes.form} onSubmit={e => addNewTeamMember(e)}>
         <Paper className={classes.paper}>
-          <Typography variant="title">Add A New Team Member</Typography>
+          <Typography variant="title">
+            {teamMember ? "Edit Team Member" : "Add A New Team Member"}
+          </Typography>{" "}
           <Divider className={classes.divider} />
           <MemberInfoForm
             state={state}
@@ -79,7 +90,7 @@ function Add(props) {
             teamMembers={props.teamMembers}
           />
           <SelectSlackID state={state} updateMember={updateMember} />
-          {Object.keys(teamMember).length ? (
+          {teamMember ? (
             <EditButtons state={state} />
           ) : (
             <AddButtons
@@ -95,7 +106,6 @@ function Add(props) {
 }
 
 const mapStateToProps = state => ({
-  teamMember: state.teamMembersReducer.teamMember,
   teamMembers: state.teamMembersReducer.teamMembers
 });
 

--- a/src/components/Sections/TeamMembers/Add/reducer/index.js
+++ b/src/components/Sections/TeamMembers/Add/reducer/index.js
@@ -16,6 +16,18 @@ export const initialState = {
   memberMentor: ""
 };
 
+const emptyUser = {
+  first_name: "",
+  last_name: "",
+  job_description: "",
+  email: "",
+  phone_number: "",
+  user_id: "",
+  slack_uuid: "",
+  manager_id: "",
+  mentor_id: ""
+};
+
 export const reducer = (state, action) => {
   switch (action.type) {
     case "UPDATE_MEMBER":
@@ -25,6 +37,8 @@ export const reducer = (state, action) => {
       };
     case "EDITING_MEMBER":
       return { ...state, teamMember: action.payload };
+    case "CLEAR_MEMBER":
+      return { ...state, teamMember: emptyUser };
     case "TOGGLE_ROUTING":
       return { ...state, isRouting: !state.isRouting };
     case "UPDATE_DISABLED":


### PR DESCRIPTION
# Description

Fixes issue where going in to view an existing team member would cause the member's info to persist in state and populate the "Add new member" view forms. Also fixes validation error where empty manager_id and mentor_id values were being submitted as empty strings (needed for React form control) when the BE Joi validation can only handle a `null` value or a number.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested locally within browser with @ajb85 assisting via Zoom.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
