### PR TITLE
:bug: fixed links to github and linkedin for team page

### DIFF
--- a/src/components/Containers/LandingPage/LandingPage/LandingPage.js
+++ b/src/components/Containers/LandingPage/LandingPage/LandingPage.js
@@ -1,6 +1,5 @@
 // contains all components for landing page
 import React from "react";
-import { Link } from "react-router-dom";
 import { scroller, animateScroll as scroll } from "react-scroll";
 import CssBaseline from "@material-ui/core/CssBaseline";
 

--- a/src/components/Containers/LandingPage/Team/Team.js
+++ b/src/components/Containers/LandingPage/Team/Team.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { ArrowUpward } from "@material-ui/icons";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
@@ -67,18 +66,24 @@ class Team extends React.Component {
                 <Typography variant="title">Nick Cannariato</Typography>
                 <p>Full-Stack Developer</p>
                 <PortfolioLink
-                  target="blank"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   href="https://github.com/nickcannariato"
                 >
                   Portfolio Site
                 </PortfolioLink>
 
                 <TeamMemberLinks>
-                  <a target="blank" href="https://github.com/nickcannariato">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/nickcannariato"
+                  >
                     <FontAwesomeIcon className="fa-2x" icon={faGithubSquare} />
                   </a>
                   <a
-                    target="blank"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.linkedin.com/in/nickcannariato/"
                   >
                     <FontAwesomeIcon className="fa-2x" icon={faLinkedin} />
@@ -89,16 +94,25 @@ class Team extends React.Component {
                 <img src={Gannon} alt="Gannon Darcy" />
                 <Typography variant="title">Gannon Darcy</Typography>
                 <p>Full-Stack Developer</p>
-                <PortfolioLink target="blank" href="http://gannon.dev">
+                <PortfolioLink
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="http://gannon.dev"
+                >
                   Portfolio Site
                 </PortfolioLink>
 
                 <TeamMemberLinks>
-                  <a target="blank" href="https://github.com/GannonDetroit">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/GannonDetroit"
+                  >
                     <FontAwesomeIcon className="fa-2x" icon={faGithubSquare} />
                   </a>
                   <a
-                    target="blank"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.linkedin.com/in/gannon-darcy-b8345073/"
                   >
                     <FontAwesomeIcon className="fa-2x" icon={faLinkedin} />
@@ -109,16 +123,25 @@ class Team extends React.Component {
                 <img src={AJ} alt="Andrew Brush" />
                 <Typography variant="title">Andrew Brush</Typography>
                 <p>Full-Stack Developer</p>
-                <PortfolioLink target="blank" href="http://ajbrush.com/">
+                <PortfolioLink
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="http://ajbrush.com/"
+                >
                   Portfolio Site
                 </PortfolioLink>
 
                 <TeamMemberLinks>
-                  <a target="blank" href="https://github.com/ajb85">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/ajb85"
+                  >
                     <FontAwesomeIcon className="fa-2x" icon={faGithubSquare} />
                   </a>
                   <a
-                    target="blank"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.linkedin.com/in/andrew-brush-58205b122/"
                   >
                     <FontAwesomeIcon className="fa-2x" icon={faLinkedin} />
@@ -130,18 +153,24 @@ class Team extends React.Component {
                 <Typography variant="title">Thomas Hessburg</Typography>
                 <p>Full-Stack Developer</p>
                 <PortfolioLink
-                  target="blank"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   href="https://github.com/TomHessburg"
                 >
                   Portfolio Site
                 </PortfolioLink>
 
                 <TeamMemberLinks>
-                  <a target="blank" href="https://github.com/TomHessburg">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/TomHessburg"
+                  >
                     <FontAwesomeIcon className="fa-2x" icon={faGithubSquare} />
                   </a>
                   <a
-                    target="blank"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.linkedin.com/in/thomas-hessburg-596948180/"
                   >
                     <FontAwesomeIcon className="fa-2x" icon={faLinkedin} />
@@ -153,18 +182,23 @@ class Team extends React.Component {
                 <Typography variant="title">Adam McKenney</Typography>
                 <p>Full-Stack Developer</p>
                 <PortfolioLink
-                  target="blank"
+                  target="_blank"
                   href="https://github.com/DaftBeowulf"
                 >
                   Portfolio Site
                 </PortfolioLink>
 
                 <TeamMemberLinks>
-                  <a target="blank" href="https://github.com/DaftBeowulf">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/DaftBeowulf"
+                  >
                     <FontAwesomeIcon className="fa-2x" icon={faGithubSquare} />
                   </a>
                   <a
-                    target="blank"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.linkedin.com/in/adam-mckenney-04827a35/"
                   >
                     <FontAwesomeIcon className="fa-2x" icon={faLinkedin} />


### PR DESCRIPTION


# Description

when you click on a link to GitHub, linkedIn, or portfolios it would open in a new tab but if you clicked on more than one, it would override that new tab. made a minor change to allow multiple new tabs to be opened and added a line to each tag for security purposes as well.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

on my local machine

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
