### PR TITLE
Fix/training series bugs

### DIFF
--- a/src/components/Pages/TeamMembers/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/Assign/Assign.js
@@ -49,7 +49,7 @@ function Assign(props) {
           Assign Members
         </Button>
       </HeaderContainer>
-      <List teamMembers={assignedMembers} />
+      <List teamMembers={assignedMembers} history={history} />
       {props.teamMembers.length && !assignedMembers.length && (
         <>
           <Typography variant="subheading" className={classes.messageTextTop}>

--- a/src/components/Pages/TeamMembers/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/Assign/Assign.js
@@ -46,10 +46,10 @@ function Assign(props) {
           variant={"outlined"}
           onClick={() => history.push(`/home/assign-members/${props.ts_id}`)}
         >
-          Assign Members
+          {assignedMembers.length ? "Assign More Members" : "Assign Members"}
         </Button>
       </HeaderContainer>
-      <List teamMembers={assignedMembers} history={history} />
+      <List params={params} teamMembers={assignedMembers} history={history} />
       {props.teamMembers.length && !assignedMembers.length && (
         <>
           <Typography variant="subheading" className={classes.messageTextTop}>

--- a/src/components/Pages/TeamMembers/List/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/List/Assign/Assign.js
@@ -5,7 +5,7 @@ import { styles, ListStyles } from "./styles.js";
 import { withStyles } from "@material-ui/core/styles";
 import { ListItem, ListItemText } from "@material-ui/core/";
 
-function Assign({ classes, teamMembers }) {
+function Assign({ classes, teamMembers, history }) {
   return (
     <>
       {teamMembers.map(member => {
@@ -15,7 +15,10 @@ function Assign({ classes, teamMembers }) {
           .format("MMMM Do, YYYY");
         return (
           <ListStyles key={member.id}>
-            <ListItem className={classes.listItem}>
+            <ListItem
+              className={classes.listItem}
+              onClick={e => history.push(`/home/team-member/${member.id}`)}
+            >
               <ListItemText
                 primary={`Member: ${member.first_name} ${member.last_name}`}
                 secondary={`Start Date: ${formattedStartDate}`}

--- a/src/components/Pages/TeamMembers/List/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/List/Assign/Assign.js
@@ -1,11 +1,13 @@
 import React from "react";
 import moment from "moment";
 
-import { styles, ListStyles } from "./styles.js";
+import DeleteModal from "components/UI/Modals/deleteModal";
+
+import { styles, ListStyles, ListButtonContainer } from "./styles.js";
 import { withStyles } from "@material-ui/core/styles";
 import { ListItem, ListItemText } from "@material-ui/core/";
 
-function Assign({ classes, teamMembers, history }) {
+function Assign({ classes, teamMembers, history, params }) {
   return (
     <>
       {teamMembers.map(member => {
@@ -15,14 +17,20 @@ function Assign({ classes, teamMembers, history }) {
           .format("MMMM Do, YYYY");
         return (
           <ListStyles key={member.id}>
-            <ListItem
-              className={classes.listItem}
-              onClick={e => history.push(`/home/team-member/${member.id}`)}
-            >
+            <ListItem className={classes.listItem}>
               <ListItemText
                 primary={`Member: ${member.first_name} ${member.last_name}`}
                 secondary={`Start Date: ${formattedStartDate}`}
+                onClick={e => history.push(`/home/team-member/${member.id}`)}
               />
+              <ListButtonContainer>
+                <DeleteModal
+                  className={`material-icons ${classes.icons}`}
+                  deleteType="unassign"
+                  id={member.id}
+                  ts_id={params.id}
+                />
+              </ListButtonContainer>
             </ListItem>
           </ListStyles>
         );

--- a/src/components/Pages/TeamMembers/List/Assign/styles.js
+++ b/src/components/Pages/TeamMembers/List/Assign/styles.js
@@ -3,7 +3,6 @@ import styled from "styled-components";
 export const styles = theme => ({
   listStyle: {
     display: "flex",
-
     padding: "5px"
   },
   listItem: {
@@ -35,4 +34,11 @@ export const styles = theme => ({
 
 export const ListStyles = styled.div`
   display: flex;
+  transition: background-color 0.3s;
+  &:hover {
+    width: 100%;
+    cursor: pointer;
+    background-color: whitesmoke;
+  }
+  border-bottom: 1px solid #e1e1e1;
 `;

--- a/src/components/Pages/TeamMembers/List/Assign/styles.js
+++ b/src/components/Pages/TeamMembers/List/Assign/styles.js
@@ -6,7 +6,7 @@ export const styles = theme => ({
     padding: "5px"
   },
   listItem: {
-    width: "79%",
+    width: "100%",
     height: 95,
     display: "flex",
 
@@ -41,4 +41,13 @@ export const ListStyles = styled.div`
     background-color: whitesmoke;
   }
   border-bottom: 1px solid #e1e1e1;
+`;
+
+export const ListButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  margin-left: 40px;
+  padding-right: 5px;
 `;

--- a/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
+++ b/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
@@ -108,7 +108,7 @@ function AddMemberToTrainingSeries(props) {
     });
     newNotifications.forEach(n => {
       memberComMethods.map(member => {
-        //this looks at the communication methods set by clicking o nthe radio buttons.
+        //this looks at the communication methods set by clicking on the radio buttons.
         //it then assigns which type of notification should be sent out based on what you clicked.
         //if you forgot to click anything, it defaults to SMS.
         if (n.team_member_id === member.id) {
@@ -119,6 +119,14 @@ function AddMemberToTrainingSeries(props) {
     });
     props.history.push(`/home/training-series/${props.match.params.id}`);
   };
+
+  //grabs list of all tmIDs currently assigned to TS (they have a notification assigned to them and this TS)
+  const filteredMemberIds = props.notifications
+    .filter(n => n.training_series_id === parseInt(props.match.params.id))
+    .map(n => n.team_member_id);
+  const assignedIds = props.teamMembers
+    .filter(m => filteredMemberIds.includes(m.id))
+    .map(m => m.id);
 
   return (
     <Wrapper>
@@ -141,6 +149,7 @@ function AddMemberToTrainingSeries(props) {
               key={member.id}
               teamMember={member}
               handelAddComMethod={handelAddComMethod}
+              assigned={assignedIds.includes(member.id)}
             />
           );
         })}
@@ -176,7 +185,8 @@ const mapStateToProps = state => {
   return {
     messages: state.messagesReducer.messages,
     teamMembers: state.teamMembersReducer.teamMembers,
-    trainingSeries: state.trainingSeriesReducer.trainingSeries
+    trainingSeries: state.trainingSeriesReducer.trainingSeries,
+    notifications: state.notificationsReducer.notifications
   };
 };
 

--- a/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
+++ b/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import moment from "moment";
 import styled from "styled-components";
 
@@ -136,7 +137,7 @@ function AddMemberToTrainingSeries(props) {
           )[0].title}
       </h1>
       <p>
-        Employee's will be sent{" "}
+        Employees will be sent{" "}
         {
           props.messages.filter(
             m => m.training_series_id === parseInt(props.match.params.id)
@@ -156,20 +157,29 @@ function AddMemberToTrainingSeries(props) {
           );
         })}
       </div>
-      <form noValidate>
-        <TextField
-          id="date"
-          label="Start Date"
-          type="date"
-          defaultValue={moment().format("YYYY-MM-DD")}
-          InputLabelProps={{
-            shrink: true
-          }}
-          onChange={e => {
-            setStartDate(e.target.value); //gives a text version of date in YYY-MM-DD
-          }}
-        />
-      </form>
+      {unassignedMembers.length ? (
+        <form noValidate>
+          <TextField
+            id="date"
+            label="Start Date"
+            type="date"
+            defaultValue={moment().format("YYYY-MM-DD")}
+            InputLabelProps={{
+              shrink: true
+            }}
+            onChange={e => {
+              setStartDate(e.target.value); //gives a text version of date in YYY-MM-DD
+            }}
+          />
+        </form>
+      ) : (
+        <p>
+          All your available team members are already assigned to this training
+          series, either click Cancel to return or{" "}
+          <Link to="/home/create-team-member">click here</Link> to create more
+          team members.
+        </p>
+      )}
       <Button
         style={{ margin: "15px" }}
         variant="contained"
@@ -178,6 +188,17 @@ function AddMemberToTrainingSeries(props) {
         onClick={e => handleSubmit(e)}
       >
         submit
+      </Button>
+      <Button
+        style={{ margin: "15px" }}
+        variant="contained"
+        color="accent"
+        type="submit"
+        onClick={e =>
+          props.history.push(`/home/training-series/${props.match.params.id}`)
+        }
+      >
+        cancel
       </Button>
     </Wrapper>
   );

--- a/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
+++ b/src/components/Pages/TrainingSeries/Add/AddMemberToTrainingSeries.js
@@ -124,10 +124,9 @@ function AddMemberToTrainingSeries(props) {
   const filteredMemberIds = props.notifications
     .filter(n => n.training_series_id === parseInt(props.match.params.id))
     .map(n => n.team_member_id);
-  const assignedIds = props.teamMembers
-    .filter(m => filteredMemberIds.includes(m.id))
-    .map(m => m.id);
-
+  const unassignedMembers = props.teamMembers.filter(
+    m => !filteredMemberIds.includes(m.id)
+  );
   return (
     <Wrapper>
       <h1>
@@ -136,20 +135,23 @@ function AddMemberToTrainingSeries(props) {
             series => parseInt(series.id) === parseInt(props.match.params.id)
           )[0].title}
       </h1>
-      {/* need to filter these messages to get current series messages only */}
       <p>
-        Employee's will be sent {props.messages.length} message(s) throughout
-        this training series.
+        Employee's will be sent{" "}
+        {
+          props.messages.filter(
+            m => m.training_series_id === parseInt(props.match.params.id)
+          ).length
+        }{" "}
+        message(s) throughout this training series.
       </p>
       <div>
-        {props.teamMembers.map(member => {
+        {unassignedMembers.map(member => {
           return (
             <SingleMemberCheck
               addMember={addMember}
               key={member.id}
               teamMember={member}
               handelAddComMethod={handelAddComMethod}
-              assigned={assignedIds.includes(member.id)}
             />
           );
         })}

--- a/src/components/Pages/TrainingSeries/Add/MessagePage.js
+++ b/src/components/Pages/TrainingSeries/Add/MessagePage.js
@@ -118,7 +118,6 @@ class MessagePage extends React.Component {
                 value={this.state.message.link}
                 onChange={this.handleChange("link")}
                 margin="normal"
-                required
               />
               <TextField
                 id="outlined-number"

--- a/src/components/Pages/TrainingSeries/Add/singleMemberCheck.js
+++ b/src/components/Pages/TrainingSeries/Add/singleMemberCheck.js
@@ -5,9 +5,10 @@ import styled from "styled-components";
 export default function SingleMemberCheck({
   addMember,
   teamMember,
-  handelAddComMethod
+  handelAddComMethod,
+  assigned
 }) {
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState(assigned);
 
   const [textChecked, setTextChecked] = useState(false);
   const [emailChecked, setEmailChecked] = useState(false);

--- a/src/components/Pages/TrainingSeries/Add/singleMemberCheck.js
+++ b/src/components/Pages/TrainingSeries/Add/singleMemberCheck.js
@@ -5,10 +5,9 @@ import styled from "styled-components";
 export default function SingleMemberCheck({
   addMember,
   teamMember,
-  handelAddComMethod,
-  assigned
+  handelAddComMethod
 }) {
-  const [checked, setChecked] = useState(assigned);
+  const [checked, setChecked] = useState(false);
 
   const [textChecked, setTextChecked] = useState(false);
   const [emailChecked, setEmailChecked] = useState(false);

--- a/src/components/Pages/TrainingSeries/Edit/Edit.js
+++ b/src/components/Pages/TrainingSeries/Edit/Edit.js
@@ -23,13 +23,13 @@ function Edit(props) {
             You're currently on the "Training Series" page. You can start adding
             messages by clicking on "Add Message". Your messages will be tied to
             this series, and whenever you assign a team member to this training
-            series, they will recieve those messages based on the "days from
+            series, they will receive those messages based on the "days from
             start" value you give each message.
             <br />
             <br />
             Once you've created some messages, feel free to assign a team member
-            to this series. Set the date in which youd like for the team member
-            to start recieving the materials, and they will recieve scheduled
+            to this series. Set the date in which you'd like for the team member
+            to start receiving the materials, and they will receive scheduled
             notifications based on the messages that you've scheduled for them.
           </p>
         }

--- a/src/components/UI/Modals/deleteModal.js
+++ b/src/components/UI/Modals/deleteModal.js
@@ -13,7 +13,8 @@ import {
   deleteTrainingSeries,
   deleteTeamMember,
   deleteMessage,
-  deleteUser
+  deleteUser,
+  unassignTeamMember
 } from "store/actions/";
 
 import { Typography, Paper } from "@material-ui/core";
@@ -108,6 +109,8 @@ class TrainingSeriesModal extends React.Component {
         this.props.deleteUser(this.props.id);
         this.props.reRouteOnDelete();
         break;
+      case "unassign":
+        this.props.unassignTeamMember(this.props.id, this.props.ts_id);
       default:
         break;
     }
@@ -191,6 +194,7 @@ export default connect(
     deleteMessage,
     deleteTeamMember,
     deleteUser,
-    deleteTrainingSeries
+    deleteTrainingSeries,
+    unassignTeamMember
   }
 )(withRouter(TrainingSeriesModalWrapped));

--- a/src/store/actions/messagesActions.js
+++ b/src/store/actions/messagesActions.js
@@ -35,9 +35,9 @@ export const getAllMessages = () => dispatch => {
 export const createAMessage = (message, trainingSeriesID) => dispatch => {
   dispatch({ type: ADD_MESSAGE_START });
   axios
-    .post(`${process.env.REACT_APP_API}/api/messages`, message) //endpoint validated
+    .post(`${process.env.REACT_APP_API}/api/messages`, message)
     .then(res => {
-      dispatch({ type: ADD_MESSAGE_SUCCESS, payload: res.data.newMessage }); //response is correct
+      dispatch({ type: ADD_MESSAGE_SUCCESS, payload: res.data.newMessage });
       history.push(`/home/training-series/${trainingSeriesID}`);
     })
     .catch(err => dispatch({ type: ADD_MESSAGE_FAIL, error: err }));
@@ -47,13 +47,12 @@ export const createAMessage = (message, trainingSeriesID) => dispatch => {
 export const editMessage = (id, updates) => dispatch => {
   dispatch({ type: EDIT_MESSAGE_START });
   axios
-    .put(`${process.env.REACT_APP_API}/api/messages/${id}`, updates) //endpoint validated, but should endpoint now be req.body.updates?
-    .then(
-      res =>
-        dispatch({
-          type: EDIT_MESSAGE_SUCCESS,
-          payload: res.data.updatedMessage
-        }) //response validated
+    .put(`${process.env.REACT_APP_API}/api/messages/${id}`, updates)
+    .then(res =>
+      dispatch({
+        type: EDIT_MESSAGE_SUCCESS,
+        payload: res.data.updatedMessage
+      })
     )
     .catch(err => dispatch({ type: EDIT_MESSAGE_FAIL, error: err }));
 };
@@ -61,10 +60,8 @@ export const editMessage = (id, updates) => dispatch => {
 // DELETE a message
 export const deleteMessage = id => dispatch => {
   dispatch({ type: DELETE_MESSAGE_START });
-  const url = `${process.env.REACT_APP_API}/api/messages/${id}`;
-  console.log(url);
   axios
-    .delete(url) //endpint validated
-    .then(() => dispatch({ type: DELETE_MESSAGE_SUCCESS, payload: id })) //100000%
+    .delete(`${process.env.REACT_APP_API}/api/messages/${id}`)
+    .then(() => dispatch({ type: DELETE_MESSAGE_SUCCESS, payload: id }))
     .catch(err => dispatch({ type: DELETE_MESSAGE_FAIL, error: err }));
 };

--- a/src/store/actions/notificationsActions.js
+++ b/src/store/actions/notificationsActions.js
@@ -15,6 +15,11 @@ export const DELETE_NOTIFICATION_START = "DELETE_NOTIFICATION_START";
 export const DELETE_NOTIFICATION_SUCCESS = "DELETE_NOTIFICATION_SUCCESS";
 export const DELETE_NOTIFICATION_FAIL = "DELETE_NOTIFICATION_FAIL";
 
+// DELETE NOTIFICATIONS BY UNASSIGNING TEAM MEMBER
+export const UNASSIGN_START = "UNASSIGN_START";
+export const UNASSIGN_SUCCESS = "UNASSIGN_SUCCESS";
+export const UNASSIGN_FAIL = "UNASSIGN_FAIL";
+
 // GET all notifications (BE is set up so it will only retrieve notifications for logged-in user)
 export const getNotifications = () => dispatch => {
   dispatch({ type: GET_NOTIFICATIONS_START });
@@ -52,4 +57,18 @@ export const deleteNotification = id => dispatch => {
       dispatch({ type: DELETE_NOTIFICATION_SUCCESS, payload: id });
     })
     .catch(err => dispatch({ type: DELETE_NOTIFICATION_FAIL, error: err }));
+};
+
+// DELETE notifications by unassigning a team member from a training series
+export const unassignTeamMember = (tm_id, ts_id) => dispatch => {
+  dispatch({ type: UNASSIGN_START });
+  axios
+    .delete(
+      `${process.env.REACT_APP_API}/api/team-members/${tm_id}/unassign/${ts_id}`
+    )
+    .then(res => {
+      console.log(res);
+      dispatch({ type: UNASSIGN_SUCCESS, payload: res.data.ids });
+    })
+    .catch(err => dispatch({ type: UNASSIGN_FAIL, error: err }));
 };

--- a/src/store/reducers/notificationsReducer.js
+++ b/src/store/reducers/notificationsReducer.js
@@ -7,7 +7,10 @@ import {
   ADD_NOTIFICATION_FAIL,
   DELETE_NOTIFICATION_START,
   DELETE_NOTIFICATION_SUCCESS,
-  DELETE_NOTIFICATION_FAIL
+  DELETE_NOTIFICATION_FAIL,
+  UNASSIGN_START,
+  UNASSIGN_SUCCESS,
+  UNASSIGN_FAIL
 } from "../actions";
 
 const initialState = {
@@ -61,6 +64,24 @@ const notificationsReducer = (state = initialState, action) => {
         notifications: state.notifications.filter(n => n.id !== action.payload)
       };
     case DELETE_NOTIFICATION_FAIL:
+      return {
+        ...state,
+        error: action.error
+      };
+    // unassigned member
+    case UNASSIGN_START:
+      return {
+        ...state,
+        error: ""
+      };
+    case UNASSIGN_SUCCESS:
+      return {
+        ...state,
+        notifications: state.notifications.filter(
+          n => !action.payload.includes(n.id)
+        )
+      };
+    case UNASSIGN_FAIL:
       return {
         ...state,
         error: action.error


### PR DESCRIPTION
# Description

Host of changes to improve functionality and style of training series view. User can now click on member in Assigned list for Training Series and be taken to their page. In edit message view, link is no longer required. New actions/reducer cases for a team member being unassigned, accesses new BE endpoint `/api/team-members/:id/unassign/:ts_id` which deletes all notifications that have the proper tm_id and ts_id, and (in an update to the endpoint) return an array of all the deleted notif ids. Proper filtering applied for add team members view so only unassigned members will show up. Altered filtering for message counts in assign members view to only track the number of messages for the specific training series. Cancel button at bottom of component allows user to go back to training series view. Message displays if no unassigned members exist directing user to either go back or create more members with link. Styling applied to Assigned Members view to match style of app.

Note: successful implementation will require update from [https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/pull/65](#65) in order to work.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally within browser, and in Postman/local db where relevant.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
