### PR TITLE
:pencil2: Remove the trailing slash from the deploy URL

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@ We've configured a one-click deploy to Netlify that will allow you to get the fr
 
 **Note**: Make sure you've completed the [Auth0 section of the prerequisite docs](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/docs/prerequisites.md#configuring-auth0) in the [Training Bot API repository](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE)
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/labs12-training-bot-2/labs12-training-bot-2-FE/)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/labs12-training-bot-2/labs12-training-bot-2-FE)
 
 ## Components
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,9 +4,9 @@
   command = "yarn build"
 
 [template.environment]
-  REACT_APP_PROD = "Replace with your Auth0 Callback URL (i.e. http://app.netlify.com/callback"
-  REACT_APP_API = "Replace with your API's url (i.e. https://app.herokuapp.com"
-  NODE_PATH = "src/"
+  REACT_APP_PROD = "Your Auth0 Callback URL (no trailing slash)"
+  REACT_APP_API = "Your production API url (no trailing slash)"
+  NODE_PATH = "Your NODE_PATH (src/)"
 
 # Redirect all requests to our domain to our client-side router
 [[redirects]]


### PR DESCRIPTION
# Description

Apparently, when there's a trailing slash on the deploy URL the button fails.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested locally, worked like a charm.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
