### PR TITLE
:sparkles: Reintroduces getAllResponses

### DIFF
--- a/src/components/Pages/Dashboard/Dashboard/Dashboard.js
+++ b/src/components/Pages/Dashboard/Dashboard/Dashboard.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 
+import { getAllResponses } from "store/actions";
+
 import SearchCard from "components/UI/SearchCard/";
 import TeamMembersOverview from "components/Pages/TeamMembers/List/Overview";
 import TeamMembersTab from "components/Pages/TeamMembers/List/Tab";
@@ -8,7 +10,6 @@ import TrainingSeriesOverview from "components/Pages/TrainingSeries/List/Overvie
 import TrainingSeriesTab from "components/Pages/TrainingSeries/List/Tab";
 import NotificationsCard from "components/Pages/Notifications/Card";
 import NotificationsOverview from "components/Pages/Notifications/Card/Overview/Overview.js";
-//import NotificationsTab from "components/Pages/Notifications/Card/NotificationsTab.js";
 import Responses from "components/Pages/Notifications/Responses";
 import TabNavigation from "./helpers/TabNavigation.js";
 import DektopNavigation from "./helpers/DesktopNavigation.js";
@@ -25,7 +26,19 @@ import {
 function Dashboard(props) {
   const [topTab, setTopTab] = useState("overview");
   const [newResponses, setNewResponses] = useState([]);
-  const { user_id, history, responses } = props;
+  const {
+    user_id,
+    history,
+    responses,
+    getAllResponses: responsesFromProps
+  } = props;
+
+  useEffect(() => {
+    responsesFromProps();
+    setTimeout(() => {
+      responsesFromProps();
+    }, 60 * 1000);
+  }, [responsesFromProps]);
 
   useEffect(() => {
     setNewResponses(responses.filter(r => !r.seen));
@@ -113,5 +126,5 @@ const mapStateToProps = state => ({
 
 export default connect(
   mapStateToProps,
-  null
+  { getAllResponses }
 )(Dashboard);

--- a/src/components/Pages/Notifications/Responses/Responses.js
+++ b/src/components/Pages/Notifications/Responses/Responses.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 
 import SlackLogo from "img/slacklogo.jpg";
 
-import { seeResponse } from "store/actions";
+import { getAllResponses, seeResponse } from "store/actions";
 
 import { withStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
@@ -22,9 +22,13 @@ import {
 } from "./styles.js";
 
 function Responses(props) {
-  const { classes, responses } = props;
+  const { classes, responses, getAllResponses: responsesFromProps } = props;
   const [service, setService] = useState("");
   const [allResponses, setAllResponses] = useState([]);
+
+  useEffect(() => {
+    responsesFromProps();
+  }, [responsesFromProps]);
 
   useEffect(() => {
     setAllResponses(responses.filter(r => !r.seen));
@@ -149,6 +153,6 @@ const mapStateToProps = state => ({
 export default withStyles(styles)(
   connect(
     mapStateToProps,
-    { seeResponse }
+    { getAllResponses, seeResponse }
   )(Responses)
 );

--- a/src/store/actions/responsesActions.js
+++ b/src/store/actions/responsesActions.js
@@ -72,6 +72,19 @@ export const deleteResponse = id => dispatch => {
     .catch(err => dispatch({ tye: DELETE_RESPONSE_FAIL }));
 };
 
+// GET all responses for the logged-in user
+export const getAllResponses = () => dispatch => {
+  dispatch({ type: GET_RESPONSES_START });
+  axios
+    .get(`${process.env.REACT_APP_API}/api/responses`)
+    .then(res => {
+      dispatch({ type: GET_RESPONSES_SUCCESS, payload: res.data.responses });
+    })
+    .catch(err => {
+      dispatch({ type: GET_RESPONSES_FAIL, error: err });
+    });
+};
+
 export const seeResponse = id => {
   return { type: SEE_RESPONSE, payload: id };
 };


### PR DESCRIPTION
# Description

Bringing back getAllResponses functionality per how @ajb85 had originally written it in that had been mistakenly removed as it was labeled for testing only.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Difficult to run tests as authorizing slack in local instance still redirects to deployed URL of trainingbot.app, but did not cause the app to break

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
