### PR TITLE
:speech_balloon: Updates portfolio links

### DIFF
--- a/src/components/Pages/LandingPage/Team/Team.js
+++ b/src/components/Pages/LandingPage/Team/Team.js
@@ -155,7 +155,7 @@ class Team extends React.Component {
                 <PortfolioLink
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://github.com/TomHessburg"
+                  href="https://thomashessburg.com/"
                 >
                   Portfolio Site
                 </PortfolioLink>
@@ -181,10 +181,7 @@ class Team extends React.Component {
                 <AdamsIMG src={Adam} alt="Adam McKenney" />
                 <Typography variant="title">Adam McKenney</Typography>
                 <p>Full-Stack Developer</p>
-                <PortfolioLink
-                  target="_blank"
-                  href="https://github.com/DaftBeowulf"
-                >
+                <PortfolioLink target="_blank" href="https://adammckenney.dev/">
                   Portfolio Site
                 </PortfolioLink>
 


### PR DESCRIPTION
Portfolio links in team page for myself and Tom now link to our hosted portfolio sites instead of github profiles.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

In browser, for real

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
