### PR TITLE
:wrench: Sets absolute path with jsconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION

# Description

Absolute path now set with jsconfig file instead of soon-to-be-deprecated NODE_PATH .env variable method. Brought about since I was playing with Dockerfile options and build would fail without the .env variable (and you don't want to push environment variables in), but as @nickcannariato reminded me, per the create-react-team setting the path in the .env file will soon be deprecated anyway and needed to be changed. This PR make sthe config file to solve that issue without relying on the path being set in local .env

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Deleted NODE_PATH variable from .env and tested locally, build would normally fail since many imports are used in this code with absolute paths. jsconfig.json file added with path set and app builds as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
