### PR TITLE
:bug: Fixes issue in TS tab

### DIFF
--- a/src/components/Pages/TrainingSeries/List/Tab/Tab.js
+++ b/src/components/Pages/TrainingSeries/List/Tab/Tab.js
@@ -1,13 +1,12 @@
 // main page for displaying list of all training series
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
-
+import { Link } from "react-router-dom";
 import {
   getTrainingSeries,
   getAllMessages,
   deleteTrainingSeries
 } from "store/actions";
-//import DeleteModal from "components/UI/Modals/deleteModal";
 import history from "history.js";
 
 import { Grid, Typography } from "@material-ui/core/";
@@ -34,7 +33,7 @@ function Tab({
         const tsMessages = messages.filter(msg => {
           return msg.training_series_id === id;
         });
-        let selectedId = tsMessages[0].id;
+        let selectedId = tsMessages.length > 0 ? tsMessages[0].id : null;
         const daysLong = Math.max(...tsMessages.map(m => m.days_from_start));
 
         return (
@@ -102,8 +101,9 @@ function Tab({
               ) : (
                 <Grid item xs={12} align="center">
                   <p>
-                    This training series doesn't have any messages yet. Click on
-                    it to add its first message.
+                    This training series doesn't have any messages yet.{" "}
+                    <Link to={`/home/training-series/${id}`}>Click here</Link>{" "}
+                    to add its first message.
                   </p>
                 </Grid>
               )}


### PR DESCRIPTION
# Description

Fixes issue for Training Series Tab where it would try to grab the id of the first message for the TS and assign it to the selectedID variable--normally not a problem, but would throw an error if any TS got loaded that had no messages related to it. Now checks the length of messages for the TS before assigning selectedID. Also adds Link component in message for empty TS so a user can immediately go add messages for it, and removed unused useState import to remove console warning.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally in browser--no more errors when a TS with no Messages is loaded in TS Tab, and empty "click here" message link successfully redirects to individual TS view.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
