### PR TITLE
:lipstick: Updates multi-card views to match card height

### DIFF
--- a/src/components/Pages/TeamMembers/Add/styles.js
+++ b/src/components/Pages/TeamMembers/Add/styles.js
@@ -95,6 +95,7 @@ export const styles = theme => ({
 
 export const MainContainer = styled.div`
   margin: 0 auto;
+  padding: 0 1px;
   max-width: ${props => props.maxWidth || "768px"};
   max-height: ${props => props.maxHeight || "none"};
   @media (max-width: 768px) {
@@ -118,7 +119,7 @@ export const MemberInfoContainer = styled.div`
 
 export const ButtonContainer = styled.div`
   display: flex;
-  margin: 10px;
+  margin: 43px 10px;
   justify-content: center;
 `;
 

--- a/src/components/Pages/TeamMembers/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/Assign/Assign.js
@@ -42,7 +42,7 @@ function Assign(props) {
   return (
     <Paper className={classes.paper}>
       <HeaderContainer>
-        <Typography variant="title" className={classes.assignedTitle}>
+        <Typography variant="h5" className={classes.assignedTitle}>
           Assigned Team Members
         </Typography>
         <Button

--- a/src/components/Pages/TeamMembers/Assign/styles.js
+++ b/src/components/Pages/TeamMembers/Assign/styles.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const styles = theme => ({
   paper: {
-    width: "100%",
+    width: "90%",
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[5],
     padding: theme.spacing.unit * 4,

--- a/src/components/Pages/TeamMembers/List/Assign/styles.js
+++ b/src/components/Pages/TeamMembers/List/Assign/styles.js
@@ -9,6 +9,7 @@ export const styles = theme => ({
     width: "100%",
     height: 95,
     display: "flex",
+    margin: "3.8px 0",
 
     "@media (max-width: 768px)": {
       width: "100%",

--- a/src/components/Pages/TrainingSeries/Edit/styles.js
+++ b/src/components/Pages/TrainingSeries/Edit/styles.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const styles = theme => ({
   paper: {
-    width: "100%",
+    width: "90%",
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[5],
     padding: theme.spacing.unit * 4,


### PR DESCRIPTION
Cards in Edit TM and Edit TS now have their cards the same height

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally in browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
