### PR TITLE
Fix/text overflow

### DIFF
--- a/src/components/Pages/Notifications/Card/Overview/Overview.js
+++ b/src/components/Pages/Notifications/Card/Overview/Overview.js
@@ -70,6 +70,10 @@ function Overview(props) {
             >
               <ListItemIcon>{displayedLogo[name]}</ListItemIcon>
               <ListItemText
+                style={{
+                  overflow: "hidden",
+                  whiteSpace: "nowrap"
+                }}
                 primary={`${subject} | ${series}`}
                 secondary={`${first_name} ${last_name}`}
               />

--- a/src/components/Pages/Notifications/Card/Overview/Overview.js
+++ b/src/components/Pages/Notifications/Card/Overview/Overview.js
@@ -32,6 +32,13 @@ function Overview(props) {
     getNotifications();
   }, [getNotifications]);
 
+  // Placeholder function to prevent text overflow of displayed fields
+  // as too many conflicting styles being applied to the three instances
+  // of the same notifications component throughout app without one breaking
+  const preventOverflow = (str, limit) => {
+    return str.length > limit ? str.slice(0, limit) + "..." : str;
+  };
+
   const displayedLogo = {
     twilio: <TextsmsOutlined />,
     sendgrid: <EmailOutlined />,
@@ -74,8 +81,11 @@ function Overview(props) {
                   overflow: "hidden",
                   whiteSpace: "nowrap"
                 }}
-                primary={`${subject} | ${series}`}
-                secondary={`${first_name} ${last_name}`}
+                primary={`${preventOverflow(subject, 20)} | ${preventOverflow(
+                  series,
+                  20
+                )}`}
+                secondary={`${preventOverflow(first_name + last_name, 40)}`}
               />
               <Typography className={classes.send_date}>
                 {filters.status === "pending" ? "Send Date" : "Sent on"}

--- a/src/components/Pages/Notifications/Card/TeamMember/TeamMember.js
+++ b/src/components/Pages/Notifications/Card/TeamMember/TeamMember.js
@@ -54,6 +54,10 @@ function TeamMember({
               <ListItemIcon>{displayedLogo[name]}</ListItemIcon>
 
               <ListItemText
+                style={{
+                  overflow: "hidden",
+                  whiteSpace: "nowrap"
+                }}
                 className={classes.item}
                 primary={`${subject} | ${series}`}
                 secondary={`${first_name} ${last_name}`}

--- a/src/components/Pages/Notifications/Responses/Responses.js
+++ b/src/components/Pages/Notifications/Responses/Responses.js
@@ -97,7 +97,7 @@ function Responses(props) {
                   className={classes.card}
                 >
                   <CardContent>
-                    <Typography variant="h5" component="h2">
+                    <Typography noWrap variant="h5" component="h2">
                       {response.first_name} {response.last_name}
                     </Typography>
 
@@ -110,7 +110,7 @@ function Responses(props) {
                         : "text"}{" "}
                       {ReturnCorrectServiceLogo(response.service)}
                     </Typography>
-                    <Typography component="p">
+                    <Typography noWrap component="p">
                       {response.response}
                       <br />
                     </Typography>

--- a/src/components/Pages/Notifications/Responses/Responses.js
+++ b/src/components/Pages/Notifications/Responses/Responses.js
@@ -10,6 +10,8 @@ import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import Button from "@material-ui/core/Button";
+import FormControl from "@material-ui/core/FormControl";
+import Select from "@material-ui/core/Select";
 import Typography from "@material-ui/core/Typography";
 import SettingsCell from "@material-ui/icons/SettingsCell";
 import Email from "@material-ui/icons/Email";
@@ -23,7 +25,7 @@ import {
 
 function Responses(props) {
   const { classes, responses, getAllResponses: responsesFromProps } = props;
-  const [service, setService] = useState("");
+  const [service, setService] = useState("all");
   const [allResponses, setAllResponses] = useState([]);
 
   useEffect(() => {
@@ -53,25 +55,32 @@ function Responses(props) {
   return (
     <MainWrapper>
       <HeaderWrapper>
-        <Typography variant="h5">Your Message Responses</Typography>
+        <Typography variant="h5">Message Responses</Typography>
         <div>
           <Typography
             className={classes.title}
             color="textSecondary"
             gutterBottom
-          >
-            filter by:
-          </Typography>
-          <select
-            onChange={e => {
-              setService(e.target.value);
-            }}
-          >
-            <option value="">all</option>
-            <option value="slack">slack</option>
-            <option value="twillo">text</option>
-            <option value="sendgrid">email</option>
-          </select>
+          />
+          <FormControl className={classes.formControl}>
+            <Select
+              native
+              className={classes.selection}
+              value={service}
+              onChange={e => {
+                setService(e.target.value);
+              }}
+              inputProps={{
+                id: "kind-selector",
+                label: "Filter Selector"
+              }}
+            >
+              <option value={"all"}>All</option>
+              <option value={"twilio"}>Text</option>
+              <option value={"sendgrid"}>Email</option>
+              <option value={"slack"}>Slack</option>
+            </Select>
+          </FormControl>
         </div>
       </HeaderWrapper>
 

--- a/src/components/Pages/Notifications/Responses/styles.js
+++ b/src/components/Pages/Notifications/Responses/styles.js
@@ -15,6 +15,12 @@ export const styles = {
   },
   pos: {
     marginBottom: 12
+  },
+  selection: {
+    margin: "0 10px",
+    "@media (max-width: 450px)": {
+      fontSize: "0.9rem"
+    }
   }
 };
 
@@ -31,9 +37,9 @@ export const MainWrapper = styled(Paper)`
 `;
 export const HeaderWrapper = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: flex-end;
   padding: 10px;
-  border-bottom: 1px solid gray;
   @media (max-width: 700px) {
     justify-content: space-between;
   }
@@ -43,12 +49,6 @@ export const HeaderWrapper = styled.div`
     @media (max-width: 700px) {
       margin: 0 20px 0 10px;
     }
-  }
-  select {
-    width: 125px;
-    margin-left: 10px;
-    height: 25px;
-    border: 1px solid black;
   }
   div {
     display: flex;

--- a/src/components/Pages/TeamMembers/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/Assign/Assign.js
@@ -81,13 +81,15 @@ function Assign(props) {
           </HolderText>
         </Typography>
       )}
-      <Pagination
-        limit={limit}
-        offset={offset}
-        total={assignedMembers.length}
-        centerRipple={true}
-        onClick={(e, newOffset) => setOffset(newOffset)}
-      />
+      <div className={classes.footer}>
+        <Pagination
+          limit={limit}
+          offset={offset}
+          total={assignedMembers.length}
+          centerRipple={true}
+          onClick={(e, newOffset) => setOffset(newOffset)}
+        />
+      </div>
     </Paper>
   );
 }

--- a/src/components/Pages/TeamMembers/Assign/styles.js
+++ b/src/components/Pages/TeamMembers/Assign/styles.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 export const styles = theme => ({
   paper: {
     width: "90%",
+    minHeight: "600px",
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[5],
     padding: theme.spacing.unit * 4,
@@ -39,6 +40,12 @@ export const styles = theme => ({
     marginBottom: 20,
     textAlign: "center",
     color: "lightgray"
+  },
+  footer: {
+    display: "flex",
+    justifyContent: "space-between",
+    position: "sticky",
+    top: "100%"
   }
 });
 

--- a/src/components/Pages/TeamMembers/List/Assign/Assign.js
+++ b/src/components/Pages/TeamMembers/List/Assign/Assign.js
@@ -49,6 +49,7 @@ function Assign(props) {
         <ListStyles key={member.id}>
           <ListItem className={classes.listItem}>
             <ListItemText
+              style={{ overflow: "hidden", whiteSpace: "nowrap" }}
               primary={`Member: ${member.first_name} ${member.last_name}`}
               secondary={`Start Date: ${getStartDate(member.id)}`}
               onClick={e => history.push(`/home/team-member/${member.id}`)}

--- a/src/components/Pages/TeamMembers/List/Overview/Overview.js
+++ b/src/components/Pages/TeamMembers/List/Overview/Overview.js
@@ -31,6 +31,10 @@ function Overview({
           return (
             <SingleMember key={id} component="li" className={classes.listItem}>
               <ListItemText
+                style={{
+                  overflow: "hidden",
+                  whiteSpace: "nowrap"
+                }}
                 primary={first_name + " " + last_name}
                 secondary={`Job: ${job_description}`}
                 onClick={() => history.push(`/home/team-member/${id}`)}

--- a/src/components/Pages/TeamMembers/List/Tab/Tab.js
+++ b/src/components/Pages/TeamMembers/List/Tab/Tab.js
@@ -39,11 +39,11 @@ function Tab({ user_id, getFiltered, getTeamMembers, teamMembers, classes }) {
                 history.push(`/home/team-member/${teamMember.id}`);
               }}
             >
-              <Typography variant="subtitle1">
+              <Typography noWrap variant="subtitle1">
                 {teamMember.first_name} {teamMember.last_name}
               </Typography>
               <hr />
-              <Typography variant="subtitle2">
+              <Typography noWrap variant="subtitle2">
                 {teamMember.email || (
                   <p style={{ color: "rgba(0,0,0,0.3)" }}>No email assigned</p>
                 )}
@@ -51,8 +51,12 @@ function Tab({ user_id, getFiltered, getTeamMembers, teamMembers, classes }) {
               <Typography variant="overline">
                 {teamMember.phone_number}
               </Typography>
-              <Typography variant="overline">Mentor: {mentorName}</Typography>
-              <Typography variant="overline">Manager: {managerName}</Typography>
+              <Typography noWrap variant="overline">
+                Mentor: {mentorName}
+              </Typography>
+              <Typography noWrap variant="overline">
+                Manager: {managerName}
+              </Typography>
             </div>
             <DeleteModal
               deleteType="teamMember"

--- a/src/components/Pages/TrainingSeries/Edit/styles.js
+++ b/src/components/Pages/TrainingSeries/Edit/styles.js
@@ -51,4 +51,6 @@ export const TrainingSeriesTitle = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  overflow: hidden;
+  white-space: pre;
 `;

--- a/src/components/Pages/TrainingSeries/Edit/styles.js
+++ b/src/components/Pages/TrainingSeries/Edit/styles.js
@@ -8,6 +8,7 @@ export const styles = theme => ({
     padding: theme.spacing.unit * 4,
     outline: "none",
     margin: "5px auto",
+    minHeight: "600px",
 
     "@media (max-width: 1300px)": {
       minWidth: "750px"

--- a/src/components/Pages/TrainingSeries/List/Messages/Messages.js
+++ b/src/components/Pages/TrainingSeries/List/Messages/Messages.js
@@ -33,6 +33,7 @@ function Messages(props) {
         <ListItemContainer key={message.id}>
           <ListItem className={classes.listItem}>
             <ListItemText
+              style={{ overflow: "hidden", whiteSpace: "nowrap" }}
               primary={message.subject}
               secondary={message.body}
               className={classes.listItemText}

--- a/src/components/Pages/TrainingSeries/List/Overview/Overview.js
+++ b/src/components/Pages/TrainingSeries/List/Overview/Overview.js
@@ -44,6 +44,10 @@ function Overview({
         return (
           <ListItem key={id} component="li" className={classes.listItem}>
             <ListItemText
+              style={{
+                overflow: "hidden",
+                whiteSpace: "nowrap"
+              }}
               primary={title}
               secondary={`Messages: ${
                 tsMessages.length

--- a/src/components/Pages/TrainingSeries/List/Tab/Tab.js
+++ b/src/components/Pages/TrainingSeries/List/Tab/Tab.js
@@ -40,7 +40,9 @@ function Tab({
           <Wrapper key={`container_${id}`}>
             <Grid container spacing={24}>
               <Grid item xs={12}>
-                <Typography variant="h6">{title}</Typography>
+                <Typography noWrap variant="h6">
+                  {title}
+                </Typography>
                 <hr />
               </Grid>
 

--- a/src/components/Pages/TrainingSeries/Messages/styles.js
+++ b/src/components/Pages/TrainingSeries/Messages/styles.js
@@ -19,6 +19,12 @@ export const styles = theme => ({
   },
   textField: {
     width: "60%"
+  },
+  footer: {
+    display: "flex",
+    justifyContent: "space-between",
+    position: "sticky",
+    top: "100%"
   }
 });
 


### PR DESCRIPTION
# Description

Fixes height of the Messages and Assigned Members cards in TS Edit view as they had no min-height and needed the pagination to stick to the bottom. Adusted styles in Responses tab to match styles in other cards, such as the select form input. Prevents text overflow from any field a user can create, which is tricky since different MUI components handle it differently--due to Notifications card being passed an inline-style max-width, overview Notif card would break when displaying a field containing too many characters, so I made a custom function that truncates the strings over a certain length.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

In browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
